### PR TITLE
Remove C-ish programming declarations

### DIFF
--- a/Brain/Brain.cpp
+++ b/Brain/Brain.cpp
@@ -9,15 +9,17 @@
 
 Brain::Brain(Print *printer, Stream *streamIn, BrainDelegate *delegate)
 {
-    set(printer, streamIn, delegate, NULL);
+    set(printer, streamIn, delegate, nullptr);
 }
 
-Brain::Brain(Print *printer, Stream *streamIn, BrainDelegate *delegate, char const *code)
+Brain::Brain(Print *printer, Stream *streamIn, BrainDelegate *delegate,
+             char const *code)
 {
     set(printer, streamIn, delegate, code);
 }
 
-void Brain::set(Print *printer, Stream *streamIn, BrainDelegate *delegate, char const *code)
+void Brain::set(Print *printer, Stream *streamIn, BrainDelegate *delegate,
+                char const *code)
 {
     reset();
     _printer = printer;
@@ -31,14 +33,14 @@ void Brain::setCode(char const *code)
     _code = code;
 }
 
-void Brain::reset(void)
+void Brain::reset()
 {
     for (int i = 0; i < TAPE_SIZE; i++) {
         _cells[i] = 0;
     }
 }
 
-void Brain::run(void)
+void Brain::run()
 {
     reset();
     int _index = 0;
@@ -49,7 +51,7 @@ void Brain::run(void)
     int _indexIterations = 0;
 
     if (!_code) {
-        write("No Code!", true);  
+        write("No code given to run. Try brain.setCode(\"++>++.\")", true);
         return;
     }
 
@@ -94,8 +96,8 @@ void Brain::run(void)
                     int loops = 1;
                     while (loops > 0 && _code[_action] != '\0' ) {
                         _action++;
-                        if (loops == 1 
-                            && _code[_action] == TT_IF_ELSE 
+                        if (loops == 1
+                            && _code[_action] == TT_IF_ELSE
                             && token == TT_IF_THEN) {
                             loops--;
                             _jumps[_indexJumps] = _action;
@@ -147,7 +149,7 @@ void Brain::run(void)
                             }
                         }
                     }
-                    
+
                     _indexJumps--;
                 } else if (_code[_jumps[_indexJumps - 1]] == TT_BEGIN_FOR) {
                     _iterations[_indexIterations - 1]--;
@@ -169,10 +171,10 @@ void Brain::run(void)
 
                 break;
             }
-    
+
             default: break;
         }
-        
+
         if (_code[_action] != '\0') {
             _action++;
         }
@@ -206,7 +208,7 @@ void Brain::write(char const *str, boolean newLine)
     delay(10);
 }
 
-void Brain::write(char c) 
+void Brain::write(char c)
 {
     if (_printer) {
         _printer->print(c);
@@ -215,7 +217,7 @@ void Brain::write(char c)
     delay(10);
 }
 
-void Brain::write(int i) 
+void Brain::write(int i)
 {
     if (_printer) {
         _printer->print(i);
@@ -224,13 +226,13 @@ void Brain::write(int i)
     delay(10);
 }
 
-int Brain::read(void)
+int Brain::read()
 {
     if (_streamIn) {
         while (!_streamIn->available()) {
             // wait for input
         }
-       
+
         return _streamIn->read();
     }
 

--- a/Brain/Brain.cpp
+++ b/Brain/Brain.cpp
@@ -51,7 +51,7 @@ void Brain::run()
     int _indexIterations = 0;
 
     if (!_code) {
-        write("No code given to run. Try brain.setCode(\"++>++.\")", true);
+        write("No code given to run", true);
         return;
     }
 

--- a/Brain/Brain.h
+++ b/Brain/Brain.h
@@ -6,8 +6,8 @@
  * Copyright Brain, 2016.
  */
 
-#ifndef Brain_h
-#define Brain_h
+#ifndef BRAIN_H
+#define BRAIN_H
 
 // include types & constants of Wiring core API
 #if ARDUINO >= 100
@@ -21,7 +21,7 @@
 #include "BrainDelegate.h"
 
 // only tested on Arduino Uno and not enough memory
-// therefore, the memory is very very small
+// therefore, the memory is very very small.
 #define TAPE_SIZE 100
 #define STACK_SIZE 10
 
@@ -46,14 +46,18 @@
 #define TT_IF_END ';'
 #define TT_FLOAT '$'
 
+/**
+ * @brief Represents the Brain interpreter and also provide functions to be
+ * used in the Arduino environment.
+ */
 class Brain
 {
-
 public:
     Brain(Print *printer, Stream *streamIn, BrainDelegate *delegate);
-    Brain(Print *printer, Stream *streamIn, BrainDelegate *delegate, char const *code);
+    Brain(Print *printer, Stream *streamIn, BrainDelegate *delegate,
+          char const *code);
     void setCode(char const *code);
-    void run(void);
+    void run();
     int getValue(int index);
     void setValue(int index, int value);
 
@@ -64,13 +68,14 @@ private:
     Stream *_streamIn;
     BrainDelegate *_delegate;
 
-    void set(Print *printer, Stream *streamIn, BrainDelegate *delegate, char const *code);
+    void set(Print *printer, Stream *streamIn, BrainDelegate *delegate,
+             char const *code);
     void write(char const *str, boolean newLine);
     void write(char c);
     void write(int i);
-    int read(void);
-    void reset(void);
+    int read();
+    void reset();
 };
 
-#endif
+#endif // BRAIN_H
 


### PR DESCRIPTION
```
Remove the C way of defining functions in C such as: function(void).
```

As the behavior in C++ is completely different. A tiny documentation was
added and more is needed.

Signed-off-by: Rafael Campos Nunes rafaelnunes@engineer.com
