### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Brainduino/keywords.txt
+++ b/Brainduino/keywords.txt
@@ -12,7 +12,7 @@ Brain	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setCode KEYWORD2
+setCode	KEYWORD2
 run	KEYWORD2
 getValue	KEYWORD2
 setValue	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords